### PR TITLE
optimizing training time by not revaluating every time on the trainin…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.5.1] New default behavior - more efficient training
+
+### Changed - PLEASE READ
+
+From now on, the default behavior of the training engine is to display **training** loss/scores computed **during the epoch**. In the past, at the end of each epoch we always re-evaluated the trained model on the entire training set, but this is often not interesting as early stopping typically acts on the validation set. The behavior can be enabled again by specifying it in the config file, that is:
+
+      engine:
+      - class_name: pydgn.training.engine.TrainingEngine
+        args:
+          eval_training:  # whether to re-compute epoch loss/scores after training or use those obtained while the model is being trained with mini-batches
+            - True  # re-evaluates on training set after each training epoch, might not change much loss/score values and causes overhead
+
+The default value will be `False` from now on to save compute time.
+
 ## [1.5.0] PyDGN - Journal of Open Source Software
 
 This is the release that adheres to the changes requested by JOSS reviewers. 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2022, Federico Errica"
 author = "Federico Errica"
 
 # The full version, including alpha/beta/rc tags
-release = "1.5.0"
+release = "1.5.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/examples/MODEL_CONFIGS/config_SupToyDGN.yml
+++ b/examples/MODEL_CONFIGS/config_SupToyDGN.yml
@@ -96,7 +96,12 @@ grid:
     readout: pydgn.model.readout.graph_readout.LinearGraphReadout
 
     # Training engine
-    engine: pydgn.training.engine.TrainingEngine
+    engine:
+      - class_name: pydgn.training.engine.TrainingEngine
+        args:
+          eval_training:  # whether to re-compute epoch loss/scores after training or use those obtained while the model is being trained with mini-batches
+            - False  # default behavior since 1.5.1, saves some compute time as we are generally interested in validation scores
+            - True  # re-evaluates on training set after each training epoch, might not change much loss/score values and causes overhead
 
     # Gradient clipper (optional)
     gradient_clipper: null

--- a/pydgn/experiment/experiment.py
+++ b/pydgn/experiment/experiment.py
@@ -333,6 +333,7 @@ class Experiment:
         engine_callback = s2c(
             engine_args.get("engine_callback", DEFAULT_ENGINE_CALLBACK)
         )
+        eval_training = engine_args.get("eval_training", False)
 
         engine = engine_class(
             engine_callback=engine_callback,
@@ -347,6 +348,7 @@ class Experiment:
             plotter=plotter,
             exp_path=self.exp_path,
             evaluate_every=evaluate_every,
+            eval_training=eval_training,
             store_last_checkpoint=store_last_checkpoint,
             reset_eval_model_hidden_state=reset_eval_model_hidden_state,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydgn"
-version = "1.5.0"
+version = "1.5.1"
 description = "A Python Package for Deep Graph Networks"
 authors = [ { name="Federico Errica", email="f.errica@protonmail.com" } ]
 readme = "README.md"


### PR DESCRIPTION
…g set (default behavior from now on, can be overridden)

## Describe your changes

From now on, the default behavior of the training engine is to display **training** loss/scores computed **during the epoch**. In the past, at the end of each epoch we always re-evaluated the trained model on the entire training set, but this is often not interesting as early stopping typically acts on the validation set. The behavior can be enabled again by specifying it in the config file, that is:

      engine:
      - class_name: pydgn.training.engine.TrainingEngine
        args:
          eval_training:  # whether to re-compute epoch loss/scores after training or use those obtained while the model is being trained with mini-batches
            - True  # re-evaluates on training set after each training epoch, might not change much loss/score values and causes overhead

The default value will be `False` from now on to save compute time.

## Issue ticket number and link

Not necessary 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
